### PR TITLE
feat: add Claude Software Factory workflows

### DIFF
--- a/.github/workflows/claude-auto-assign.yml
+++ b/.github/workflows/claude-auto-assign.yml
@@ -1,0 +1,52 @@
+name: Auto-assign Claude on new issues
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  tag-claude:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      members: read
+    steps:
+      - name: Check org membership and tag Claude
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const author = context.payload.issue.user.login;
+            const org = context.repo.owner;
+            const body = context.payload.issue.body || '';
+
+            // Already has @claude — no need to add it
+            if (body.includes('@claude')) {
+              console.log('Issue body already contains @claude, skipping.');
+              return;
+            }
+
+            // Always trigger for the Claude bot itself
+            const isClaudeBot = author === 'claude[bot]';
+
+            let isMember = false;
+            if (!isClaudeBot) {
+              try {
+                await github.rest.orgs.checkMembershipForUser({ org, username: author });
+                isMember = true;
+              } catch (e) {
+                isMember = false;
+              }
+            }
+
+            if (!isClaudeBot && !isMember) {
+              console.log(`Skipping: ${author} is not a member of ${org}`);
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: '@claude please implement this issue'
+            });

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,30 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+jobs:
+  claude-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: '*'
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,44 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          allowed_bots: "claude[bot]"
+
+          additional_permissions: |
+            actions: read
+
+          claude_args: '--model claude-opus-4-6 --allowedTools "Bash(gh pr create:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(gh issue:*),Bash(gh api:*),Bash(git fetch:*),Bash(git checkout:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git rebase:*),Bash(git log:*),Bash(git diff:*),Bash(git status:*),Bash(go build:*),Bash(go vet:*),Bash(go mod tidy:*),Bash(go test:*),Edit,Write,Read,Glob,Grep"'


### PR DESCRIPTION
## Summary

- **claude.yml** — Opus 4.6 worker, responds to `@claude` in issues/comments, implements and opens PRs
- **claude-code-review.yml** — Automated code review on Sonnet via code-review plugin
- **claude-auto-assign.yml** — Auto-triggers Claude on new issues from org members

Toolset tailored for Go: `go build`, `go vet`, `go mod tidy`, `go test`.

## Secrets

| Secret | Status |
|---|---|
| `CLAUDE_CODE_OAUTH_TOKEN` | Set |