### PR TITLE
fix: use Tree.Root.String() for JS/CSS extraction to avoid html/template escaping

### DIFF
--- a/internal/pssg/render/render.go
+++ b/internal/pssg/render/render.go
@@ -245,29 +245,23 @@ func (e *Engine) render(name string, data interface{}) (string, error) {
 }
 
 // RenderCSS reads and returns the CSS template content.
+// Uses Tree.Root.String() to avoid html/template escaping in CSS code.
 func (e *Engine) RenderCSS() (string, error) {
 	t := e.tmpl.Lookup("_styles.css")
 	if t == nil {
 		return "", nil
 	}
-	var buf bytes.Buffer
-	if err := t.Execute(&buf, nil); err != nil {
-		return "", err
-	}
-	return buf.String(), nil
+	return t.Tree.Root.String(), nil
 }
 
 // RenderJS reads and returns the JS template content.
+// Uses Tree.Root.String() to avoid html/template escaping < to &lt; in JS code.
 func (e *Engine) RenderJS() (string, error) {
 	t := e.tmpl.Lookup("_main.js")
 	if t == nil {
 		return "", nil
 	}
-	var buf bytes.Buffer
-	if err := t.Execute(&buf, nil); err != nil {
-		return "", err
-	}
-	return buf.String(), nil
+	return t.Tree.Root.String(), nil
 }
 
 // GenerateCookModePrompt builds a cook-with-AI prompt for a recipe.


### PR DESCRIPTION
Fixes the remaining graph rendering issue from #10.

## Summary

`RenderJS()` and `RenderCSS()` were running `_main.js` and `_styles.css` through `html/template`'s `Execute()`, which HTML-escapes `<` to `&lt;`. This broke every for-loop and comparison in `main.js` (8 instances), causing a JS syntax error that killed the entire script before D3 graph rendering code could execute.

Same root cause as the `template.HTML` → `template.JS` fix merged in #11: the `text/template` → `html/template` migration in `8f1470b`.

## Fix

Use `t.Tree.Root.String()` instead of `t.Execute()` to return the raw template source without html/template's context-aware escaping. These files are static assets with no Go template directives.

## Verified locally

- `node --check main.js` passes (was failing with `Unexpected token ';'` before)
- D3 force graph renders correctly in browser
- All existing tests pass